### PR TITLE
Replace map type and map resolution strings with enums

### DIFF
--- a/bathy_pf.ipynb
+++ b/bathy_pf.ipynb
@@ -27,7 +27,35 @@
     "from numpy import float64, int64, sin, cos, tan, rad2deg, deg2rad, eye\n",
     "from matplotlib import pyplot as plt\n",
     "from pyins import strapdown, transform, measurements, filters, sim, earth\n",
-    "from numpy.random import multivariate_normal as mvn\n"
+    "from numpy.random import multivariate_normal as mvn\n",
+    "from src.geophysical import gmt_toolbox as gmt\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pygmt.datasets import load_earth_relief, load_earth_free_air_anomaly, load_earth_magnetic_anomaly"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "relief = gmt.GeophysicalMap(gmt.MeasurementType.RELIEF, gmt.ReliefResolution.ONE_MINUTE, -1, 1, -1, 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "relief.get_map_point(0, 0)"
    ]
   },
   {

--- a/src/data_management/dbmgr.py
+++ b/src/data_management/dbmgr.py
@@ -122,11 +122,11 @@ class Data(Base):
     alt: Mapped[float] = mapped_column(Float)
     vn: Mapped[float] = mapped_column(Float)
     ve: Mapped[float] = mapped_column(Float)
-    vd: Mapped[float] = mapped_column(Float)    
+    vd: Mapped[float] = mapped_column(Float)
     roll: Mapped[float] = mapped_column(Float)
     pitch: Mapped[float] = mapped_column(Float)
     heading: Mapped[float] = mapped_column(Float)
-    #speed: Mapped[float] = mapped_column(Float)
+    # speed: Mapped[float] = mapped_column(Float)
     gyro_x: Mapped[float] = mapped_column(Float)
     gyro_y: Mapped[float] = mapped_column(Float)
     gyro_z: Mapped[float] = mapped_column(Float)
@@ -244,7 +244,7 @@ class DatabaseManager:
                     accel_x=row["accel_x"],
                     accel_y=row["accel_y"],
                     accel_z=row["accel_z"],
-                    distance=row['distance'],
+                    distance=row["distance"],
                     depth=row["depth"],
                     mag_tot=row["mag_tot"],
                     mag_res=row["mag_res"],

--- a/src/geophysical/gmt_toolbox.py
+++ b/src/geophysical/gmt_toolbox.py
@@ -3,10 +3,16 @@ Toolbox module. Contains utility functions for accessing and manipulating geophy
 """
 
 from dataclasses import dataclass
+from enum import Enum
 import os
 
 import numpy as np
-import xarray as xr
+from numpy import array
+from numpy.typing import NDArray
+from numpy import float64, int64
+
+# import xarray as xr
+from xarray import DataArray, load_dataarray
 from anglewrapper import wrap
 from pygmt.datasets import (
     load_earth_free_air_anomaly,
@@ -14,217 +20,234 @@ from pygmt.datasets import (
     load_earth_relief,
 )
 
-# TODO: #74 replace map type and map resolution strings with enums
 
-
-def get_map_section(
-    west_lon: float,
-    east_lon: float,
-    south_lat: float,
-    north_lat: float,
-    map_type: str = "relief",
-    map_res: str = "02m",
-) -> xr.DataArray:
+class MapType(Enum):
     """
-    Function for querying the raw map to get map segments. This is the publicly facing function
-    that should be used in other modules for reading in maps from raw data. If you don't need to
-    query the GMT database and instead need to load a local map file use load_map_file() instead.
-    This function will query the remote GMT databases and return the map data as an xarray.DataArray.
-
-    Parameters
-    ----------
-    :param west_lon: West longitude value in degrees.
-    :type west_lon: float
-    :param east_lon: East longitude value in degrees.
-    :type east_lon: float
-    :param south_lat: South latitude value in degsubsectionsrees.
-    :type south_lat: float
-    :param north_lat: North latitude value in degrees.
-    :type north_lat: float
-    :param map_type: Geophysical map type (relief, gravity, magnetic)
-    :type map_type: string
-    :param map_res: map resolution of output, all maps have 01d, 30m, 20m, 15m, 10m, 06m, 05m,
-    04m, 03m, and 02m; additionally gravity and relief have 01m; additionally, relief has 30s,
-    15s, 03s, 01s
-    :type map_res: string
-
-    Returns
-    -------
-    :returns: xarray.DataArray
-
-    """
-    west_lon = wrap.to_180(west_lon)
-    east_lon = wrap.to_180(east_lon)
-    # assert that the west longitude is less than the east longitude
-    assert west_lon < east_lon, "West longitude must be less than east longitude."
-    # Validate map type and construct GMT map name to call via grdcut
-    if map_type == "gravity" and _validate_gravity_resolution(map_res):
-        out = load_earth_free_air_anomaly(
-            resolution=map_res,
-            region=[west_lon, east_lon, south_lat, north_lat],
-        )
-    elif map_type == "magnetic" and _validate_magentic_resolution(map_res):
-        out = load_earth_magnetic_anomaly(
-            resolution=map_res,
-            region=[west_lon, east_lon, south_lat, north_lat],
-        )
-    elif map_type == "relief" and _validate_relief_resoltion(map_res):
-        out = load_earth_relief(
-            resolution=map_res,
-            region=[west_lon, east_lon, south_lat, north_lat],
-        )
-    else:
-        # print("Map type not recognized")
-        raise ValueError("Map type not recognized")
-
-    return out
-
-
-def load_map_file(filepath: str) -> xr.DataArray:
-    """
-    Used to load the local .nc (netCDF4) map files in to a Python xarray DataArray structure.
-
-    Parameters
-    -----------
-    :param filepath: the filepath to the map file.
-    :type filepath: string
-
-    :returns: xarray.DataArray
-    """
-    # Add in error handling for file not found
-    if not os.path.exists(filepath):
-        raise FileNotFoundError(f"File not found: {filepath}")
-    try:
-        return xr.load_dataarray(filepath)
-    except FileNotFoundError as e:
-        print(e)
-        raise e
-
-
-def save_map_file(map_data: xr.DataArray, filepath: str) -> None:
-    """
-    Used to save the map data to a local .nc (netCDF4) file.
-
-    Parameters
-    -----------
-    :param map_data: the map data to save.
-    :type map_data: xarray.DataArray
-    :param filepath: the filepath to save the map file.
-    :type filepath: string
-
-    :returns: None
-    """
-    # Add some control flow to validate the inputs and file paths
-    assert isinstance(map_data, xr.DataArray), "map_data must be an xarray.DataArray"
-    # Check to make sure the file path is valid, if the filepath contains a directory that
-    # doesn't exist, create it
-    if not os.path.exists(os.path.dirname(filepath)):
-        os.makedirs(os.path.dirname(filepath))
-
-    map_data.to_netcdf(filepath)
-    return None
-
-
-def get_map_point(geo_map: xr.DataArray, longitudes, latitudes) -> np.ndarray:
-    """
-    Wrapper on DataArray.interp() to query the map and simply get the returned values.
-    Converting the lists of longitudes and latitudes to xarray.DataArray objects speeds
-    up the query.
-
-    Parameters
-    -----------
-    :param geo_map: the map data to query.
-    :type geo_map: xarray.DataArray
-    :param longitudes: list-like of longitudes to query.
-    :type longitudes: list-like
-    :param latitudes: list-like of latitudes to query.
-    :type latitudes: list-like
-
-    :returns: numpy.ndarray
-
-    """
-    longitudes = xr.DataArray(longitudes)
-    latitudes = xr.DataArray(latitudes)
-    vals = geo_map.interp(lon=longitudes, lat=latitudes)
-    return vals.data
-
-
-def _validate_gravity_resolution(res: str) -> bool:
-    valid = [
-        "01d",
-        "30m",
-        "20m",
-        "15m",
-        "10m",
-        "06m",
-        "05m",
-        "04m",
-        "03m",
-        "02m",
-        "01m",
-    ]
-    if any(res == R for R in valid):
-        return True
-    # else:
-    #     print("Invalid resolution for map type: GRAVITY")
-    #     return False
-    raise ValueError(f"Resolution {res} invalid for map type: GRAVITY. Valid resolutions are: {valid}")
-
-
-def _validate_magentic_resolution(res: str) -> bool:
-    valid = ["01d", "30m", "20m", "15m", "10m", "06m", "05m", "04m", "03m", "02m"]
-    if any(res == R for R in valid):
-        return True
-    raise ValueError(f"Resolution {res} invalid for map type: MAGNETIC. Valid resolutions are: {valid}")
-
-
-def _validate_relief_resoltion(res: str) -> bool:
-    valid = [
-        "1d",
-        "30m",
-        "20m",
-        "15m",
-        "10m",
-        "06m",
-        "05m",
-        "04m",
-        "03m",
-        "02m",
-        "01m",
-        "30s",
-        "15s",
-        "03s",
-        "01s",
-    ]
-    if any(res == R for R in valid):
-        return True
-
-    raise ValueError(f"Resolution {res} invalid for map type: RELIEF. Valid resolutions are: {valid}")
-
-
-def inflate_bounds(min_x, min_y, max_x, max_y, inflation_percent):
-    """
-    Used to inflate the cropping bounds for the map section
+    Enum class for PyGMT map names. Used to validate the map type and resolution.
     """
 
-    # Calculate the width and height of the original bounds
-    width = max_x - min_x
-    height = max_y - min_y
+    RELIEF = "elevation"
+    GRAVITY = "free_air_anomaly"
+    MAGNETIC = "magnetic_anomaly"
+    UNKNOWN = "unknown"
 
-    # Check if the width or height is near zero and add a small amount
-    if width <= 1e-6:
-        width = 0.1
-    if height <= 1e-6:
-        height = 0.1
+    def __str__(self):
+        if self == MapType.RELIEF:
+            return "elevation"
+        elif self == MapType.GRAVITY:
+            return "free_air_anomaly"
+        elif self == MapType.MAGNETIC:
+            return "magnetic_anomaly"
+        else:
+            return "unknown"
 
-    # Calculate the amount to inflate based on the percentage
-    inflate_x = width * inflation_percent
-    inflate_y = height * inflation_percent
+    def __repr__(self):
+        return f"MapType<{str(self)}>"
 
-    # Calculate the new minimum and maximum coordinates
-    new_min_x = min_x - inflate_x
-    new_min_y = min_y - inflate_y
-    new_max_x = max_x + inflate_x
-    new_max_y = max_y + inflate_y
 
-    return new_min_x, new_min_y, new_max_x, new_max_y
+class MeasurementType(Enum):
+    BATHYMETRY = 0
+    RELIEF = 1
+    GRAVITY = 2
+    MAGNETIC = 3
+
+    def __str__(self):
+        if self == MeasurementType.BATHYMETRY:
+            return "BATHYMETRY"
+        elif self == MeasurementType.RELIEF:
+            return "RELIEF"
+        elif self == MeasurementType.GRAVITY:
+            return "GRAVITY"
+        elif self == MeasurementType.MAGNETIC:
+            return "MAGNETIC"
+        else:
+            return "Unknown"
+
+    def __repr__(self):
+        return f"MeasurementType<{str(self)}>"
+
+
+class ReliefResolution(Enum):
+    ONE_DEGREE = "01d"
+    THIRTY_MINUTES = "30m"
+    TWENTY_MINUTES = "20m"
+    FIFTEEN_MINUTES = "15m"
+    TEN_MINUTES = "10m"
+    SIX_MINUTES = "06m"
+    FIVE_MINUTES = "05m"
+    FOUR_MINUTES = "04m"
+    THREE_MINUTES = "03m"
+    TWO_MINUTES = "02m"
+    ONE_MINUTE = "01m"
+    THIRTY_SECONDS = "30s"
+    FIFTEEN_SECONDS = "15s"
+    THREE_SECONDS = "03s"
+    ONE_SECOND = "01s"
+
+
+class GravityResolution(Enum):
+    ONE_DEGREE = "01d"
+    THIRTY_MINUTES = "30m"
+    TWENTY_MINUTES = "20m"
+    FIFTEEN_MINUTES = "15m"
+    TEN_MINUTES = "10m"
+    SIX_MINUTES = "06m"
+    FIVE_MINUTES = "05m"
+    FOUR_MINUTES = "04m"
+    THREE_MINUTES = "03m"
+    TWO_MINUTES = "02m"
+    ONE_MINUTE = "01m"
+
+
+class MagneticResolution(Enum):
+    ONE_DEGREE = "01d"
+    THIRTY_MINUTES = "30m"
+    TWENTY_MINUTES = "20m"
+    FIFTEEN_MINUTES = "15m"
+    TEN_MINUTES = "10m"
+    SIX_MINUTES = "06m"
+    FIVE_MINUTES = "05m"
+    FOUR_MINUTES = "04m"
+    THREE_MINUTES = "03m"
+    TWO_MINUTES = "02m"
+
+
+class GeophysicalMap():
+    """
+    Class for storing and validating geophysical map data. Combination of a dataclass and a
+    thin wrapper around xarray.DataArray. The class is used to store the map data and query
+    the map data for specific points. The class is also used to validate the map type and
+    resolution and to construct the map data from the GMT databases.
+    """
+
+    map_type: MeasurementType
+    map_resolution: ReliefResolution | GravityResolution | MagneticResolution
+    west_lon: float
+    east_lon: float
+    south_lat: float
+    north_lat: float
+    map_data: DataArray
+
+    def __init__(
+        self,
+        map_type: MeasurementType,
+        map_resolution: ReliefResolution | GravityResolution | MagneticResolution,
+        west_lon: float,
+        east_lon: float,
+        south_lat: float,
+        north_lat: float,
+        inflate_bounds: float = 0.0,
+    ):
+        assert isinstance(map_type, MeasurementType), "map_type must be a MeasurementType"
+        self.map_type = map_type
+        assert isinstance(
+            map_resolution, (ReliefResolution, GravityResolution, MagneticResolution)
+        ), "map_resolution must be a valid ReliefResolution, GravityResolution, or MagneticResolution"
+        self.map_resolution = map_resolution
+        west_lon = wrap.to_180(west_lon)
+        east_lon = wrap.to_180(east_lon)
+        # assert that the west longitude is less than the east longitude
+        assert west_lon < east_lon, "West longitude must be less than east longitude."
+        assert south_lat < north_lat, "South latitude must be less than north latitude."
+        # Inflate the bounds to ensure that the map section is large enough to interpolate
+        assert 0 <= inflate_bounds, "Inflation percentage must be greater than or equal to zero."
+        if inflate_bounds > 0:
+            west_lon, south_lat, east_lon, north_lat = self._inflate_bounds(
+                west_lon, south_lat, east_lon, north_lat, inflate_bounds
+            )
+        self.west_lon = west_lon
+        self.east_lon = east_lon
+        self.south_lat = south_lat
+        self.north_lat = north_lat
+        # Validate map type and construct GMT map name to call via grdcut
+        if map_type == MeasurementType.RELIEF or map_type == MeasurementType.BATHYMETRY:
+            assert isinstance(map_resolution, ReliefResolution), "map_resolution must be a ReliefResolution"
+            self.map_data = load_earth_relief(
+                resolution=map_resolution.value,
+                region=[west_lon, east_lon, south_lat, north_lat],
+            )
+        elif map_type == MeasurementType.GRAVITY:
+            assert isinstance(map_resolution, GravityResolution), "map_resolution must be a GravityResolution"
+            self.map_data = load_earth_free_air_anomaly(
+                resolution=map_resolution.value,
+                region=[west_lon, east_lon, south_lat, north_lat],
+            )
+        elif map_type == MeasurementType.MAGNETIC:
+            assert isinstance(map_resolution, MagneticResolution), "map_resolution must be a MagneticResolution"
+            self.map_data = load_earth_magnetic_anomaly(
+                resolution=map_resolution.value,
+                region=[west_lon, east_lon, south_lat, north_lat],
+            )
+        else:
+            raise ValueError("Map type not recognized")
+
+    def get_map_point(
+        self,
+        longitudes: list[int | float | int64 | float64] | NDArray[int64 | float64] | DataArray,
+        latitudes: list[int | float | int64 | float64] | NDArray[int64 | float64] | DataArray,
+    ) -> NDArray[float64]:
+        """
+        Wrapper on DataArray.interp() to query the map and simply get the returned values.
+        Converting the lists of longitudes and latitudes to xarray.DataArray objects speeds
+        up the query.
+
+        Parameters
+        -----------
+        :param geo_map: the map data to query.
+        :type geo_map: xarray.DataArray
+        :param longitudes: list-like of longitudes to query.
+        :type longitudes: list-like
+        :param latitudes: list-like of latitudes to query.
+        :type latitudes: list-like
+
+        :returns: numpy.ndarray
+
+        """
+        longitudes = DataArray(longitudes)
+        latitudes = DataArray(latitudes)
+        vals = self.map_data.interp(lon=longitudes, lat=latitudes)
+        return vals.data
+
+    def _inflate_bounds(self, min_x, min_y, max_x, max_y, inflation_percent):
+        """
+        Used to inflate the cropping bounds for the map section
+        """
+
+        # Calculate the width and height of the original bounds
+        width = max_x - min_x
+        height = max_y - min_y
+
+        # Check if the width or height is near zero and add a small amount
+        if width <= 1e-6:
+            width = 0.1
+        if height <= 1e-6:
+            height = 0.1
+
+        # Calculate the amount to inflate based on the percentage
+        inflate_x = width * inflation_percent
+        inflate_y = height * inflation_percent
+
+        # Calculate the new minimum and maximum coordinates
+        new_min_x = min_x - inflate_x
+        new_min_y = min_y - inflate_y
+        new_max_x = max_x + inflate_x
+        new_max_y = max_y + inflate_y
+
+        return new_min_x, new_min_y, new_max_x, new_max_y
+
+    def __str__(self):
+        return f"GeophysicalMap<{self.map_type}, {self.map_resolution}, {self.west_lon}, {self.east_lon}, {self.south_lat}, {self.north_lat}>"
+
+    def __repr__(self):
+        return f"GeophysicalMap<{self.map_type}, {self.map_resolution}, {self.west_lon}, {self.east_lon}, {self.south_lat}, {self.north_lat}>"
+
+    # TODO: #75 Add method to save the map data to a netCDF file
+    # def save(self, filename: str):
+    #    """
+    #    Save the map data to a netCDF file. Uses the xarray.DataArray.to_netcdf()
+    #    method but also needs to save the resolution as attributes in the netCDF file.
+    #    """
+
+    # TODO: #76 Add method to load the map data from a netCDF file
+    # @classmethod
+    # def load(self, filename: str):

--- a/test/test_gmt_toolbox.py
+++ b/test/test_gmt_toolbox.py
@@ -8,153 +8,87 @@ import unittest
 from numpy import ndarray
 from xarray import DataArray
 
-from src.geophysical import gmt_toolbox
+from src.geophysical import gmt_toolbox as tbx
 
 
-class TestGMTToolbox(unittest.TestCase):
+def test_map_type() -> None:
     """
-    Testing class
+    Test the MapType enum class.
     """
+    relief = tbx.MapType.RELIEF
+    gravity = tbx.MapType.GRAVITY
+    magnetic = tbx.MapType.MAGNETIC
+    unknown = tbx.MapType.UNKNOWN
+    assert str(relief) == "elevation"
+    assert str(gravity) == "free_air_anomaly"
+    assert str(magnetic) == "magnetic_anomaly"
+    assert str(unknown) == "unknown"
 
-    def setUp(self):
-        """
-        Set up the test environment data.
-        """
-        min_x, min_y, max_x, max_y = 0, 0, 2, 2
-        section = gmt_toolbox.get_map_section(min_x, max_x, min_y, max_y)
-        gmt_toolbox.save_map_file(section, "./test_map/test.nc")
-        gmt_toolbox.save_map_file(section, "./test.nc")
+def test_measurement_type() -> None:
+    """
+    Test the MeasurementType enumeration.
+    """
+    assert tbx.MeasurementType.GRAVITY.value == 2
+    assert tbx.MeasurementType.MAGNETIC.value == 3
+    assert tbx.MeasurementType.RELIEF.value == 1
+    assert tbx.MeasurementType.BATHYMETRY.value == 0
+    assert str(tbx.MeasurementType.BATHYMETRY) == "BATHYMETRY"
+    assert str(tbx.MeasurementType.RELIEF) == "RELIEF"
+    assert str(tbx.MeasurementType.GRAVITY) == "GRAVITY"
+    assert str(tbx.MeasurementType.MAGNETIC) == "MAGNETIC"
 
-    def tearDown(self):
-        """
-        Tear down the test environment data.
-        """
-        if os.path.exists("./test_map/test.nc"):
-            os.remove("./test_map/test.nc")
-        if os.path.exists("./test.nc"):
-            os.remove("./test.nc")
 
-    def test_inflate_bounds(self):
-        """
-        Test the inflate_bounds function.
-        """
-        min_x, min_y, max_x, max_y = 0, 0, 10, 10
-        inflation_percent = 0.1
-        new_min_x, new_min_y, new_max_x, new_max_y = gmt_toolbox.inflate_bounds(
-            min_x, min_y, max_x, max_y, inflation_percent
-        )
-        self.assertEqual(new_min_x, -1)
-        self.assertEqual(new_min_y, -1)
-        self.assertEqual(new_max_x, 11)
-        self.assertEqual(new_max_y, 11)
+def test_relief_resolution() -> None:
+    """
+    Test the relief_resolution function.
+    """
+    assert tbx.ReliefResolution.ONE_DEGREE.value == "01d"
+    assert tbx.ReliefResolution.THIRTY_MINUTES.value == "30m"
+    assert tbx.ReliefResolution.TWENTY_MINUTES.value == "20m"
+    assert tbx.ReliefResolution.FIFTEEN_MINUTES.value == "15m"
+    assert tbx.ReliefResolution.TEN_MINUTES.value == "10m"
+    assert tbx.ReliefResolution.SIX_MINUTES.value == "06m"
+    assert tbx.ReliefResolution.FIVE_MINUTES.value == "05m"
+    assert tbx.ReliefResolution.FOUR_MINUTES.value == "04m"
+    assert tbx.ReliefResolution.THREE_MINUTES.value == "03m"
+    assert tbx.ReliefResolution.TWO_MINUTES.value == "02m"
+    assert tbx.ReliefResolution.ONE_MINUTE.value == "01m"
+    assert tbx.ReliefResolution.THIRTY_SECONDS.value == "30s"
+    assert tbx.ReliefResolution.FIFTEEN_SECONDS.value == "15s"
+    assert tbx.ReliefResolution.THREE_SECONDS.value == "03s"
+    assert tbx.ReliefResolution.ONE_SECOND.value == "01s"
 
-    def test_validate_relief_resolution(self):
-        """
-        Test the validate_relief_resolution function.
-        """
-        valid = [
-            "1d",
-            "30m",
-            "20m",
-            "15m",
-            "10m",
-            "06m",
-            "05m",
-            "04m",
-            "03m",
-            "02m",
-            "01m",
-            "30s",
-            "15s",
-            "03s",
-            "01s",
-        ]
-        for res in valid:
-            self.assertTrue(gmt_toolbox._validate_relief_resoltion(res))
-        self.assertRaises(ValueError, gmt_toolbox._validate_relief_resoltion, "1s")
-        self.assertRaises(ValueError, gmt_toolbox._validate_relief_resoltion, "02s")
+def test_gravity_resolution() -> None:
+    """
+    Test the gravity resolution enum.
+    """
+    assert tbx.GravityResolution.ONE_DEGREE.value == "01d"
+    assert tbx.GravityResolution.THIRTY_MINUTES.value == "30m"
+    assert tbx.GravityResolution.TWENTY_MINUTES.value == "20m"
+    assert tbx.GravityResolution.FIFTEEN_MINUTES.value == "15m"
+    assert tbx.GravityResolution.TEN_MINUTES.value == "10m"
+    assert tbx.GravityResolution.SIX_MINUTES.value == "06m"
+    assert tbx.GravityResolution.FIVE_MINUTES.value == "05m"
+    assert tbx.GravityResolution.FOUR_MINUTES.value == "04m"
+    assert tbx.GravityResolution.THREE_MINUTES.value == "03m"
+    assert tbx.GravityResolution.TWO_MINUTES.value == "02m"
+    assert tbx.GravityResolution.ONE_MINUTE.value == "01m"
 
-    def test_validate_magentic_resolution(self):
-        """
-        Test the validate_magnetic_resolution function.
-        """
-        valid = ["01d", "30m", "20m", "15m", "10m", "06m", "05m", "04m", "03m", "02m"]
-        for res in valid:
-            self.assertTrue(gmt_toolbox._validate_magentic_resolution(res))
-        self.assertRaises(ValueError, gmt_toolbox._validate_magentic_resolution, "01s")
-        self.assertRaises(ValueError, gmt_toolbox._validate_magentic_resolution, "02s")
+def test_magnetic_resolution() -> None:
+    """
+    Test the magnetic resolution enum.
+    """
+    assert tbx.MagneticResolution.ONE_DEGREE.value == "01d"
+    assert tbx.MagneticResolution.THIRTY_MINUTES.value == "30m"
+    assert tbx.MagneticResolution.TWENTY_MINUTES.value == "20m"
+    assert tbx.MagneticResolution.FIFTEEN_MINUTES.value == "15m"
+    assert tbx.MagneticResolution.TEN_MINUTES.value == "10m"
+    assert tbx.MagneticResolution.SIX_MINUTES.value == "06m"
+    assert tbx.MagneticResolution.FIVE_MINUTES.value == "05m"
+    assert tbx.MagneticResolution.FOUR_MINUTES.value == "04m"
+    assert tbx.MagneticResolution.THREE_MINUTES.value == "03m"
+    assert tbx.MagneticResolution.TWO_MINUTES.value == "02m"
 
-    def test_validate_gravity_resolution(self):
-        """
-        Test the validate_gravity_resolution function.
-        """
-        valid = [
-            "01d",
-            "30m",
-            "20m",
-            "15m",
-            "10m",
-            "06m",
-            "05m",
-            "04m",
-            "03m",
-            "02m",
-            "01m",
-        ]
-        for res in valid:
-            self.assertTrue(gmt_toolbox._validate_gravity_resolution(res))
-        self.assertRaises(ValueError, gmt_toolbox._validate_gravity_resolution, "01s")
-        self.assertRaises(ValueError, gmt_toolbox._validate_gravity_resolution, "02s")
 
-    def test_get_map_section(self):
-        """
-        Test the get_map_section function.
-        """
-        min_x, min_y, max_x, max_y = 0, 0, 2, 2
-        # Use default relief values
-        section = gmt_toolbox.get_map_section(min_x, max_x, min_y, max_y)
-        self.assertIsInstance(section, DataArray)
-        self.assertIsNotNone(section.shape)
-        self.assertIsNotNone(section.coords)
-        # Test gravity
-        section = gmt_toolbox.get_map_section(min_x, max_x, min_y, max_y, "gravity")
-        self.assertIsInstance(section, DataArray)
-        self.assertIsNotNone(section.shape)
-        self.assertIsNotNone(section.coords)
-        # Test magnetics
-        section = gmt_toolbox.get_map_section(min_x, max_x, min_y, max_y, "magnetic")
-        self.assertIsInstance(section, DataArray)
-        self.assertIsNotNone(section.shape)
-        self.assertIsNotNone(section.coords)
-        # Test invalid
-        self.assertRaises(ValueError, gmt_toolbox.get_map_section, min_x, max_x, min_y, max_y, "other")
-
-    def test_save_map_file(self):
-        """
-        Test the save_map_file function.
-        """
-        min_x, min_y, max_x, max_y = 0, 0, 2, 2
-        section = gmt_toolbox.get_map_section(min_x, max_x, min_y, max_y)
-        gmt_toolbox.save_map_file(section, "./test.nc")
-        self.assertTrue(os.path.exists("./test.nc"))
-        gmt_toolbox.save_map_file(section, "./test_map/test.nc")
-        self.assertTrue(os.path.exists("./test_map/test.nc"))
-
-    def test_load_map_file(self):
-        """
-        Try to load ./test.nc and check if it is a DataArray.
-        """
-        section = gmt_toolbox.load_map_file("./test_map/test.nc")
-        self.assertIsInstance(section, DataArray)
-        self.assertIsNotNone(section.shape)
-        self.assertIsNotNone(section.coords)
-        self.assertRaises(FileNotFoundError, gmt_toolbox.load_map_file, "./tester.nc")
-
-    def test_get_map_point(self):
-        """
-        Test the get_map_point function.
-        """
-        min_x, min_y, max_x, max_y = 0, 0, 2, 2
-        section = gmt_toolbox.get_map_section(min_x, max_x, min_y, max_y)
-        point = gmt_toolbox.get_map_point(section, 1, 1)
-        self.assertIsInstance(point, ndarray)
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_particle_filter.py
+++ b/test/test_particle_filter.py
@@ -11,55 +11,30 @@ import unittest
 import numpy as np
 
 
-from src.geophysical.gmt_toolbox import get_map_point, get_map_section
+from src.geophysical.gmt_toolbox import GeophysicalMap, MapType, ReliefResolution, GravityResolution, MagneticResolution
 from src.geophysical.particle_filter import (
-   MeasurementType,
-   GeophysicalMeasurement,
-   ParticleFilterConfig,
-   coning_and_sculling_correction,
-   rmse,
-   propagate_imu,
-   update_anomaly,
-   update_relief,
-   vector_to_skew_symmetric,
-   skew_symmetric_to_vector,
+    MeasurementType,
+    GeophysicalMeasurement,
+    ParticleFilterConfig,
+    coning_and_sculling_correction,
+    rmse,
+    propagate_imu,
+    update_anomaly,
+    update_relief,
+    vector_to_skew_symmetric,
+    skew_symmetric_to_vector,
 )
+
 
 def test_rmse() -> None:
     """
     Test that the RMSE of a single particle at the origin is 0.
     """
-    particles = np.array([[0,0,0]])
-    truth = np.array([0,0,0])
+    particles = np.array([[0, 0, 0]])
+    truth = np.array([0, 0, 0])
     assert rmse(particles, truth) == 0
     assert rmse(particles, truth, include_altitude=True) == 0
 
-
-def test_measurement_type() -> None:
-    """
-    Test the MeasurementType enumeration.
-    """
-    assert MeasurementType.GRAVITY.value == 2
-    assert MeasurementType.MAGNETIC.value == 3
-    assert MeasurementType.RELIEF.value == 1
-    assert MeasurementType.BATHYMETRY.value == 0
-    assert str(MeasurementType.BATHYMETRY) == "BATHYMETRY"
-    assert str(MeasurementType.RELIEF) == "RELIEF"
-    assert str(MeasurementType.GRAVITY) == "GRAVITY"
-    assert str(MeasurementType.MAGNETIC) == "MAGNETIC"
-
-
-def test_geophysical_measurement()->None:
-    """
-    Test the GeophysicalMeasurement class.
-    """
-    measurement = GeophysicalMeasurement(0, 1)
-    assert str(measurement.name) == "BATHYMETRY"
-    assert measurement.std == 1
-    assert measurement.to_dict() == {
-        "name": "BATHYMETRY",
-        "std": 1
-    }
 
 def test_coning_and_sculling_correction() -> None:
     """
@@ -70,7 +45,7 @@ def test_coning_and_sculling_correction() -> None:
     current_accel = np.array([0, 0, 9.81])
     previous_gyros = np.array([0, 0, 0])
     previous_accel = np.array([0, 0, 9.81])
-    
+
     thetas, dv = coning_and_sculling_correction(current_gyros, current_accel, previous_gyros, previous_accel, dt)
     assert thetas.shape == (3,)
     assert dv.shape == (3,)
@@ -85,6 +60,7 @@ def test_vector_to_skew_symmetric() -> None:
     assert skew_symmetric.shape == (3, 3)
     assert np.all(skew_symmetric == np.array([[0, -3, 2], [3, 0, -1], [-2, 1, 0]]))
 
+
 def test_skew_symmetric_to_vector() -> None:
     """
     Test the skew-symmetric matrix to vector conversion.
@@ -93,6 +69,7 @@ def test_skew_symmetric_to_vector() -> None:
     v = skew_symmetric_to_vector(skew_symmetric)
     assert v.shape == (3,)
     assert np.all(v == np.array([1, 2, 3]))
+
 
 def test_propagate_imu() -> None:
     """
@@ -111,52 +88,54 @@ def test_update_relief() -> None:
     Test the relief update.
     """
     particles = np.random.random((10, 15))
-    relief = get_map_section(-1, 1, -1, 1, "relief", "01m")
-    observation = get_map_point(relief, 0, 0)
+    relief = GeophysicalMap(MeasurementType.RELIEF, ReliefResolution.ONE_MINUTE, -1, 1, -1, 1, 0.1)
+    observation = relief.get_map_point(0, 0)
     weights = update_relief(particles, relief, observation, 0.1)
     assert len(weights) == 10
+
 
 def test_update_anomaly() -> None:
     """
     Test the anomaly update.
     """
     particles = np.random.random((10, 15))
-    anomaly = get_map_section(-1, 1, -1, 1, "gravity", "01m")
-    observation = get_map_point(anomaly, 0, 0)
+    anomaly = GeophysicalMap(MeasurementType.GRAVITY, GravityResolution.ONE_MINUTE, -1, 1, -1, 1, 0.1)
+    observation = anomaly.get_map_point(0, 0)
     weights = update_anomaly(particles, anomaly, observation, 0.1)
     assert len(weights) == 10
-    anomaly = get_map_section(-1, 1, -1, 1, "magnetic", "01m")
-    observation = get_map_point(anomaly, 0, 0)
+    anomaly = GeophysicalMap(MeasurementType.MAGNETIC, MagneticResolution.TWO_MINUTES, -1, 1, -1, 1, 0.1)
+    observation = anomaly.get_map_point(0, 0)
     weights = update_anomaly(particles, anomaly, observation, 0.1)
     assert len(weights) == 10
+
 
 class TestParticleFilterConfig(unittest.TestCase):
     """
     Test the ParticleFilterConfig class.
     """
+
     def setUp(self) -> None:
         self.config_path = join("test", "pfconfig.json")
         pfconfig = {
-            "n" : 100,
-            "cov" : [1, 1, 1],
-            "noise" : [1, 1, 1],
-            "measurement_config" : [
+            "n": 100,
+            "cov": [1, 1, 1],
+            "noise": [1, 1, 1],
+            "measurement_config": [
                 {"name": "BATHYMETRY", "std": 1},
                 {"name": "RELIEF", "std": 1},
                 {"name": "GRAVITY", "std": 1},
-                {"name": "MAGNETIC", "std": 1}
-            ]
+                {"name": "MAGNETIC", "std": 1},
+            ],
         }
-        
+
         with open(self.config_path, "w") as f:
             json.dump(pfconfig, f)
-
 
     def tearDown(self) -> None:
         files = glob(join("test", "pfconfig*"))
         for file in files:
             remove(file)
-        
+
     def test_load(self) -> None:
         config = ParticleFilterConfig.load(self.config_path)
         assert config.n == 100


### PR DESCRIPTION
This pull request replaces the map type and map resolution strings with enums in the `geophysical_nav` repository. The changes include:

- Importing the `gmt_toolbox` module from the `src.geophysical` package

- Using the `GeophysicalMap` class from the `gmt_toolbox` module to create a geophysical map with the specified measurement type, resolution, and bounds

- Updating the code to use the new enums for measurement types (e.g., `MeasurementType.RELIEF`, `MeasurementType.GRAVITY`) instead of string literals

- Updating the code to use the new enums for relief resolution (e.g., `ReliefResolution.ONE_MINUTE`) instead of string literals

- Updating the code to use the new enums for gravity resolution (e.g., `GravityResolution.ONE_MINUTE`) instead of string literals

- Updating the code to use the new enums for magnetic resolution (e.g., `MagneticResolution.TWO_MINUTES`) instead of string literals

Fixes #74